### PR TITLE
do not show/send content-type for GET requests - fixes #16

### DIFF
--- a/views/templates/request.html
+++ b/views/templates/request.html
@@ -70,19 +70,20 @@ curl -X {{method}}{{#if headers}}{{#each headers}} -H "{{key}}:{{value}}" {{/eac
           <h4 class="fh-secondary-header">Headers</h4>
 
           <ul class="unstyled">
-              <li>
-                <label class="input-medium">Content-Type</label>
-                <select class="input-medium" name="content-type">
-                  <option name="application/json">application/json</option>
-                  <option name="application/atom+xml">application/atom+xml</option>
-                  <option name="application/x-www-form-urlencoded">application/x-www-form-urlencoded</option>
-                  <option name="application/xml">application/xml</option>
-                  <option name="multipart/form-data">multipart/form-data</option>
-                  <option name="text/html">text/html</option>
-                  <option name="text/plain">text/plain</option>
-                </select>
-                
-              </li>
+            {{#if hasBody}}
+            <li>
+              <label class="input-medium">Content-Type</label>
+              <select class="input-medium" name="content-type">
+                <option name="application/json">application/json</option>
+                <option name="application/atom+xml">application/atom+xml</option>
+                <option name="application/x-www-form-urlencoded">application/x-www-form-urlencoded</option>
+                <option name="application/xml">application/xml</option>
+                <option name="multipart/form-data">multipart/form-data</option>
+                <option name="text/html">text/html</option>
+                <option name="text/plain">text/plain</option>
+              </select>
+            </li>
+            {{/if}}
             {{#each model.headers}}
             <li class="headerRow">
               <input class="input-medium" name="headerKey{{@key}}" type="text" placeholder="Header Key" value="{{key}}">


### PR DESCRIPTION
I've tested that the content-type won't be shown or sent when request method == GET
