### PR TITLE
delete request body when saving GET request - fixes #19

### DIFF
--- a/public/js/request.view.js
+++ b/public/js/request.view.js
@@ -97,6 +97,9 @@ App.RequestView = App.BaseMapperView.extend({
     // This particular header gets treated as a separate input field, but 
     // our data schema serverside just treats it as any other header
     mappedValues.headers.push({ key : 'content-type', value : this.$contentType.val() });
+    if (mappedValues.method === 'GET'){
+      mappedValues.body = null;
+    }
     return mappedValues;
   },
   inputChanged : function(){


### PR DESCRIPTION
So it occurs that problem wasn't on frontend, it was just interpreting whatever it got from database.

But when you switch request from POST to GET, the `body` form input is not present, so `model.save(..)` won't send `body` property as part of request update, and that's why it remains intact in the DB.

So we will `nullify` it instead.
