### PR TITLE
initial set of mocha-phantomjs based frontend tests FH-1961

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -35,6 +35,10 @@
     "log" : true,
     "Backbone" : true,
     "Handlebars" : true,
-    "JSON" : true
+    "JSON" : true,
+    "describe" : true,
+    "it" : true,
+    "beforeEach" : true,
+    "assert" : true
   }   
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,4 @@
+
 module.exports = function(grunt) {
   grunt.initConfig({
     jshint: {
@@ -25,14 +26,42 @@ module.exports = function(grunt) {
           layout: 'byComponent'
         }
       }
+    },
+    mocha_phantomjs: {
+      all: {
+        options: {
+          urls: [
+            'http://localhost:9001/test/frontend-tests.html'
+          ]
+        }
+      }
     }
+  });
+
+  grunt.registerTask('serve-frontend-tests', 'Start a custom static web server.', function() {
+    var expressHasStarted = this.async();
+    grunt.log.writeln('Starting static web server in "." on port 9001.');
+    var express = require('express');
+    var app = express();
+    app.engine('html', require('ejs').renderFile);
+    app.get('/test/frontend-tests.html', function(req, res) {
+      return res.render('../test/frontend-tests.html', {});
+    });
+    app.use(express['static'](__dirname));
+
+    app.listen(9001, 'localhost', function() {
+      console.log("Express started at: " + new Date() + " on port: " + 9001);
+      expressHasStarted();
+    });
   });
 
   grunt.loadNpmTasks('grunt-fh-build');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-nodemon');
   grunt.loadNpmTasks('grunt-bower-task');
+  grunt.loadNpmTasks('grunt-mocha-phantomjs');
   grunt.registerTask('serve', ['bower', 'nodemon']);
-  grunt.registerTask('test', ['jshint', 'fh:unit']);
+  grunt.registerTask('test', ['jshint', 'fh:unit', 'test-frontend']);
   grunt.registerTask('default', ['bower', 'test']);
+  grunt.registerTask('test-frontend', ['serve-frontend-tests', 'mocha_phantomjs']);
 };

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
+    "chai": "3.3.0",
     "grunt": "0.4.5",
     "grunt-bower-task": "0.4.0",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-jshint": "0.11.2",
     "grunt-fh-build": "0.1.0",
+    "grunt-mocha-phantomjs": "^2.0.0",
     "grunt-nodemon": "^0.4.0",
     "jshint": "2.7.0",
     "mocha": "2.2.4",

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,19 +1,20 @@
 var App = {};
-$(function(){
+
+App.init = function() {
   var path = window.location.pathname || "",
   id, model;
   // replace last trailing /
   path = path.replace(/\/$/, "");
   path = path.split('/');
   id = _.last(path);
-  
+
   // Always have requestsListView as the bottom view in the stack
   var listView = new App.RequestsListView().render();
-  
+
   if (!path || !id){
     return;
   }
-  
+
   if (id === 'new'){
     // Show create new page
     return listView.listenToOnce(listView.collection, 'sync', function(){
@@ -21,18 +22,14 @@ $(function(){
       return listView.showRequestView(new App.RequestModel());
     });
   }
-  
+
   model = new App.RequestModel({ _id : id });
-  model.fetch({ 
-    success : function(){ 
+  model.fetch({
+    success : function(){
       listView.showRequestView(model);
     },
     error : function(){
       listView.notify('failure', 'Failed to load request with id ' + id);
-    } 
+    }
   });
-  
-  
-  
-  
-});
+};

--- a/public/js/request.view.js
+++ b/public/js/request.view.js
@@ -24,16 +24,19 @@ App.RequestView = App.BaseMapperView.extend({
   },
   render : function(){
     var model = this.model.toJSON();
+
+    this.methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+
     this.$el.html(this.tpl({
       model : model,
       isNew : this.model.isNew(),
-      hasBody : typeof model.method !== 'undefined' && model.method !== 'GET'
+      hasBody : typeof model.method !== 'undefined' && model.method !== 'GET',
+      methods : this.methods
     }));
     
     this.$form = this.$el.find('form');
     this.$url = this.$el.find('input[name=url]');
     this.$method = this.$el.find('select[name=method]');
-    
     this.$editableHeaders = this.$el.find('#editableHeaders');
     this.$data = this.$el.find('textarea[name=data]');
     this.$requestHeaders = this.$el.find('.request-headers');

--- a/test/frontend-tests.html
+++ b/test/frontend-tests.html
@@ -1,0 +1,57 @@
+<html>
+<meta charset="utf-8">
+<head>
+  <title>Backbone.js Tests</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+</head>
+<body>
+<% include ../views/templates/common.html %>
+<% include ../views/templates/common.html %>
+<% include ../views/templates/requests.html %>
+<% include ../views/templates/request.html %>
+
+<div id="mocha"></div>
+
+<!-- Test Fixtures. -->
+<div id="fixtures" style="display: none; visibility: hidden;"></div>
+
+<!-- JavaScript Test Libraries. -->
+<script src="../node_modules/mocha/mocha.js"></script>
+<script src="../node_modules/chai/chai.js"></script>
+
+<!-- JavaScript Core Libraries -->
+<script src="../public/lib/underscore/underscore.js"></script>
+<script src="../public/lib/jquery/js/jquery.min.js"></script>
+<script src="../public//lib/handlebars/handlebars.js"></script>
+<script src="../public/lib/backbone/backbone.js"></script>
+<script src="../public/lib/bootstrap/bootstrap.js"></script>
+
+<script src="../public/templates/helpers.js"></script>
+<script src="../public/js/app.js"></script>
+<script src="../public/js/logger.js"></script>
+<script src="../public/js/base.view.js"></script>
+<script src="../public/js/requests.view.js"></script>
+<script src="../public/js/request.view.js"></script>
+<script src="../public/js/request.model.js"></script>
+<script src="../public/js/requests.collection.js"></script>
+
+<!-- Set up Mocha and Chai -->
+<script>
+  var assert = chai.assert;
+  mocha.setup({
+    ui: "bdd",
+    bail: false
+  });
+
+  window.onload = function () {
+    (window.mochaPhantomJS || mocha).run();
+  };
+</script>
+
+<!-- Include our specs. -->
+<script src="frontend-tests/test-request.view.js"></script>
+
+</body>
+</html>

--- a/test/frontend-tests/test-request.view.js
+++ b/test/frontend-tests/test-request.view.js
@@ -1,0 +1,78 @@
+describe("App.RequestView", function () {
+
+  var view, model;
+
+  beforeEach(function () {
+    model = new App.RequestModel();
+    view = new App.RequestView({ model: model });
+    view.render();
+  });
+
+  describe("getFormValuesAsJSON", function () {
+
+    describe("headers", function() {
+
+      it("no content-type for GET requests", function () {
+        view.$method.val('GET').trigger('change');
+        var contentType = view.$editableHeaders.find('[name=content-type]').val('text/plain');
+        assert.equal(contentType.size(), 0);
+        var data = view.getFormValuesAsJSON();
+        assert.isArray(data.headers);
+        assert.equal(data.headers.length, 0);
+        assert.deepEqual(data.headers, []);
+      });
+
+      it("content-type options are available for non-GET requests", function() {
+        assert.isArray(view.methods);
+        _.each(view.methods, function( method ) {
+          if (method !== 'GET') {
+            view.$method.val(method).trigger('change');
+            var contentType = view.$editableHeaders.find('[name=content-type]').val('text/plain');
+            assert.equal(contentType.size(), 1);
+
+            var data = view.getFormValuesAsJSON();
+            assert.isArray(data.headers);
+            assert.equal(data.headers.length, 1);
+            assert.propertyVal(data.headers[0], "key", "content-type");
+            assert.propertyVal(data.headers[0], "value", "text/plain");
+          }
+        });
+      });
+
+      it("allows to customize headers", function () {
+        view.$method.val('GET').trigger('change');
+        view.$editableHeaders.find('[name="headers.key"]').val('Authorization');
+        view.$editableHeaders.find('[name="headers.value"]').val('Bearer ABCTOKEN=');
+        var data = view.getFormValuesAsJSON();
+        assert.isArray(data.headers);
+        assert.equal(data.headers.length, 1);
+        assert.propertyVal(data.headers[0], "key", "Authorization");
+        assert.propertyVal(data.headers[0], "value", "Bearer ABCTOKEN=");
+      });
+
+    });
+
+    describe("body", function() {
+
+      it("no body for GET requests", function () {
+        view.$method.val('GET').trigger('change');
+        var body = view.$el.find('[name=body]');
+        assert.equal(body.length, 0);
+      });
+
+      it("body is available for non-GET requests", function() {
+        assert.isArray(view.methods);
+        _.each(view.methods, function( method ) {
+          if (method !== 'GET') {
+            view.$method.val(method).trigger('change');
+            var body = view.$el.find('[name=body]');
+            assert.equal(body.length, 1);
+            body.val('{}');
+            var data = view.getFormValuesAsJSON();
+            assert.equal(data.body, '{}');
+          }
+        });
+      });
+    });
+  });
+});

--- a/views/index.html
+++ b/views/index.html
@@ -25,5 +25,8 @@
     <script src="/js/request.view.js"></script>
     <script src="/js/request.model.js"></script>
     <script src="/js/requests.collection.js"></script>
+    <script>
+      $(App.init);
+    </script>
   </body>
 </html>

--- a/views/templates/request.html
+++ b/views/templates/request.html
@@ -50,13 +50,13 @@ curl -X {{method}}{{#if headers}}{{#each headers}} -H "{{key}}:{{value}}" {{/eac
       <li>
         <label class="input-medium">Content-Type</label>
         <select class="input-medium" name="content-type">
-          <option name="application/json">application/json</option>
-          <option name="application/atom+xml">application/atom+xml</option>
-          <option name="application/x-www-form-urlencoded">application/x-www-form-urlencoded</option>
-          <option name="application/xml">application/xml</option>
-          <option name="multipart/form-data">multipart/form-data</option>
-          <option name="text/html">text/html</option>
-          <option name="text/plain">text/plain</option>
+          <option value="application/json">application/json</option>
+          <option value="application/atom+xml">application/atom+xml</option>
+          <option value="application/x-www-form-urlencoded">application/x-www-form-urlencoded</option>
+          <option value="application/xml">application/xml</option>
+          <option value="multipart/form-data">multipart/form-data</option>
+          <option value="text/html">text/html</option>
+          <option value="text/plain">text/plain</option>
         </select>
         
       </li>
@@ -84,13 +84,9 @@ curl -X {{method}}{{#if headers}}{{#each headers}} -H "{{key}}:{{value}}" {{/eac
 
           <div class="input-append fh-request-input">
             <select name="method" class="span2">
-              <option>GET</option>
-              <option>POST</option>
-              <option>PUT</option>
-              <option>PATCH</option>
-              <option>DELETE</option>
-              <option>HEAD</option>
-              <option>OPTIONS</option>
+              {{#each methods}}
+              <option>{{this}}</option>
+              {{/each}}
             </select>
             <input name="url" value="{{model.url}}" class="span8" id="appendedPrependedDropdownButton" type="text" placeholder="Enter Request URL here">
             <button class="btn btn-primary" type="submit">Send Request</button>


### PR DESCRIPTION
- tests are using `mocha-phantomjs` as a runner
- test files are served by a simple express server that interprets `ejs` (includes handlebars templates)
- tests are placed into `frontend-tests` directory (to be discussed, I would maybe prefer `spec` terminology)
- tests are written in mocha `bdd` syntax, since frontend tests do no allow to make use of `exports` :-( (we could perhaps consider unification with unit nodejs tests here)
- some changes in views and `App.init` required to make the views testable

@cianclarke could you take a look?
