### PR TITLE
Show request states in CSS classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 #Component: fh-api-mapper
 
+## 1.0.1 - 2015-09-25 - Cian Clarke
+* Hide response section until request completes.
+
 ## 1.0.0 - 2015-09-23 - Cian Clarke
 * Rest Client service. Bower deps checked in, bugs fixed. 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-api-mapper",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "dependencies": {
     "body-parser": "1.13.3",
     "cors": "2.7.1",

--- a/public/css/styles.less
+++ b/public/css/styles.less
@@ -123,10 +123,29 @@
   }
 }
 
+.request-pending{
+  .loader{
+   display: block; 
+  }
+}
+
+
+.request-done{
+  .fh-result{
+    display: block;
+  }  
+}
+
+.loader{
+  display: none; 
+}
 
 .fh-result{
   padding: 10px 0 40px 0;
+  display: none;
 }
+
+
 
 
 

--- a/public/js/request.view.js
+++ b/public/js/request.view.js
@@ -161,13 +161,13 @@ App.RequestView = App.BaseMapperView.extend({
     this.$responseHeaders.val('');
     this.$responseRaw.text('');
     this.$status.text('In progress...');
-    this.$form.addClass('request-pending').removeClass('request-failed');
+    this.$el.addClass('request-pending').removeClass('request-done');
     this.$sampleNodejs.val('');
     
     
   },
   onRequestSuccess : function(data){
-    this.$form.removeClass('request-pending');
+    this.$el.removeClass('request-pending').addClass('request-done');
     var request = data.request,
     response = data.response,
     $tplHeaders = Handlebars.compile($('#tplHeaders').html());
@@ -181,7 +181,7 @@ App.RequestView = App.BaseMapperView.extend({
   onRequestFailed : function(status, responseRaw){
     this.$status.text(status);
     this.$responseRaw.text(responseRaw);
-    this.$form.addClass('request-failed').removeClass('request-pending');
+    this.$el.addClass('request-done').removeClass('request-pending');
   },
   parseHeaders : function( raw ) {
     var headers = {};

--- a/views/templates/request.html
+++ b/views/templates/request.html
@@ -129,6 +129,16 @@ curl -X {{method}}{{#if headers}}{{#each headers}} -H "{{key}}:{{value}}" {{/eac
     </form><!-- container -->
   </section><!-- fh-request -->
 
+
+  <section class="loader">
+    <div class="container">
+      <div class="row">
+        <div class="span12">
+          <p class="text-center">LOADING...</p>
+        </div>
+      </div>
+    </div>
+  </section>
   <section class="fh-result">
     <div class="container">
       <div class="row">


### PR DESCRIPTION
@andresgalante If you fork this branch, you should have states you can use on the top level div. The `.request` div will have:  
`.request-pending` when requests are loading  
`.request-done` when requests have failed or succeeded (=> when the placeholders are populated) 
