### PR TITLE
README update to tell the user to upgrade database if the button is available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ There are currently some workarounds needed to get the API Mapper up and running
 
 1. Make the newly created service public
 ![Public Service](/public/images/publicservice.jpg)
-2. Visit the data browser, and upgrade the database so this application has it's own database. Note the application needs to be first finished its initial deploy and be running to perform this task. 
+2. Visit the data browser, depending on your application configuration a "Upgrade Database" action will be available, this means the application is using an old/legacy shared database and it needs to be upgraded to use a dedicated one. Note the application needs to be first finished its initial deploy and be running to perform this task.
 ![Public Service](/public/images/databrowser.jpg)
 3. Re-deploy the service
 4. You can now use the API mapper under the "Preview" section of the studio. The mapper can be popped out of the studio fullscreen by visiting the deploy host of this service in a web browser. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-api-mapper",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "bin": {
     "bower": "node_modules/bower/bin/bower",
     "browserify": "node_modules/browserify/bin/cmd.js"


### PR DESCRIPTION
# Motivation

The "Upgrade Database" button is not available in OpenShift 3 Cloud Apps, so the documentation needs to explain that the user should click this button if it is available/shown.
# Changes

Changed step 2 in setup section.

[RHMAP-6206](https://issues.jboss.org/browse/RHMAP-6206)

ping @david-martin 
