### PR TITLE
WIP - Added platform authentication (basic auth dialog) for all endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "backbone": "^1.2.3",
+    "basic-auth": "^1.1.0",
     "body-parser": "1.13.3",
     "bootstrap": "^3.3.4",
     "bower": "^1.7.2",
@@ -24,6 +25,7 @@
     "mongoose-validators": "^0.1.0",
     "patternfly": "^2.8.0",
     "request": "2.61.0",
+    "rhmap-auth": "^1.0.1",
     "stream-buffers": "2.2.0",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
## Motivation

Show we can hook up authentication into API mapper. 
Currently authentication would be required for both GUI and actual mappings, which is not right thing to do. We can add this to some particular mappings to trigger different behavior.
Creating to open conversation what particular endpoints should be secured and what security we should use. Main areas here:
- Static endpoints (html,js)
- API for creating rules/mappings (design)
- API for actual mappings (runtime)
