### PR TITLE
Update fh-mbaas-api to version 8.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ services:
   - mongodb
   - docker
 node_js:
-  - "0.10"
   - "4.4.3"
+  - "6.9.1"
 before_install:
   - npm install -g bower
   - export PHANTOMJS_CDNURL=https://bitbucket.org/ariya/phantomjs/downloads npm install phantomjs

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cors": "2.7.1",
     "ejs": "^2.3.4",
     "express": "4.13.3",
-    "fh-mbaas-api": "~7.0.12",
+    "fh-mbaas-api": "~8.0.1",
     "font-awesome": "^4.4.0",
     "handlebars": "^3.0.3",
     "jquery": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "backbone": "^1.2.3",
     "body-parser": "1.13.3",
     "bootstrap": "^3.3.4",
-    "bower": "^1.7.2",
+    "bower": "1.3.x",
     "brace": "^0.7.0",
     "browserify": "^12.0.1",
     "cors": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "less-middleware": "^2.0.1",
     "mongoose": "^4.1.4",
     "mongoose-validators": "^0.1.0",
-    "patternfly": "^2.8.0",
+    "patternfly": "1.3.0",
     "request": "2.79.0",
     "stream-buffers": "2.2.0",
     "underscore": "^1.8.3"


### PR DESCRIPTION
- Remove node 0.10 (no longer supported on rhamp) and add 6.9.1

- Downgrade `bower` because `bootstrap-treeview@1.2.0` wants `bower@1.3.x`. See [here](https://github.com/jonmiles/bootstrap-treeview/blob/v1.2.0/package.json#L40) and see [here](https://travis-ci.org/feedhenry-templates/fh-api-mapper/jobs/274536064#L705) for the build failure. 

- Downgrade `patternfly` because `patternfly@2.10.0` has `grunt-contrib-less@1.4.1` which installs `grunt@1.0.1` and results in peer dependency errors (see [here](https://travis-ci.org/feedhenry-templates/fh-api-mapper/jobs/274540271#L730) for the build failure).  